### PR TITLE
ci(gameserver): build with multiple JDK versions

### DIFF
--- a/gameserver/Containerfile
+++ b/gameserver/Containerfile
@@ -1,4 +1,4 @@
-ARG server_img=docker.io/itzg/minecraft-server:java21-jdk
+ARG server_img=docker.io/itzg/minecraft-server:java21
 ARG agent_version
 
 FROM quay.io/cryostat/cryostat-agent-init:${agent_version} AS agent

--- a/gameserver/build.bash
+++ b/gameserver/build.bash
@@ -14,21 +14,31 @@ trap cleanup EXIT
 BUILD_IMG="${APP_REGISTRY:-quay.io}/${APP_NAMESPACE:-redhat-java-monitoring}/${APP_NAME:-gameserver-cryostat-agent}"
 BUILD_TAG="${APP_VERSION:-latest}"
 CRYOSTAT_AGENT_VERSION="${CRYOSTAT_AGENT_VERSION:-0.5.0-SNAPSHOT}"
+IFS=', ' read -r -a ARCHS <<< "${IMAGE_ARCHS:-amd64 arm64}"
+IFS=', ' read -r -a JDKS <<< "${JDK_VERSIONS:-11 17 21}"
 
-podman manifest create "${BUILD_IMG}:${BUILD_TAG}"
+for jdk in "${JDKS[@]}"; do
+    podman manifest create "${BUILD_IMG}:${BUILD_TAG}-jdk${jdk}"
+done
 
-for arch in amd64 arm64; do
-    echo "Building for ${arch} ..."
-    podman build --build-arg agent_version="${CRYOSTAT_AGENT_VERSION,,}" --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/Containerfile" "${DIR}"
-    podman manifest add "${BUILD_IMG}:${BUILD_TAG}" containers-storage:"${BUILD_IMG}:linux-${arch}"
+for arch in "${ARCHS[@]}"; do
+  for jdk in "${JDKS[@]}"; do
+    echo "Building JDK ${jdk} for ${arch} ..."
+    podman build --build-arg server_img="docker.io/itzg/minecraft-server:java${jdk}" --build-arg agent_version="${CRYOSTAT_AGENT_VERSION,,}" --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}-jdk${jdk}" -f "${DIR}/Containerfile" "${DIR}"
+    podman manifest add "${BUILD_IMG}:${BUILD_TAG}-jdk${jdk}" containers-storage:"${BUILD_IMG}:linux-${arch}-jdk${jdk}"
+  done
 done
 
 for tag in ${TAGS}; do
-    podman tag "${BUILD_IMG}:${BUILD_TAG}" "${BUILD_IMG}:${tag}"
+    for jdk in "${JDKS[@]}"; do
+        podman tag "${BUILD_IMG}:${BUILD_TAG}-jdk${jdk}" "${BUILD_IMG}:${tag}-jdk${jdk}"
+    done
 done
 
 if [ "${PUSH_MANIFEST}" = "true" ]; then
     for tag in ${TAGS}; do
-        podman manifest push "${BUILD_IMG}:${tag}" "docker://${BUILD_IMG}:${tag}"
+        for jdk in "${JDKS[@]}"; do
+            podman manifest push "${BUILD_IMG}:${tag}-jdk${jdk}" "docker://${BUILD_IMG}:${tag}-jdk${jdk}"
+        done
     done
 fi


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Based on #13

## Description of the change:
Builds the gameserver container with an array of JDK versions.

## Motivation for the change:
Currently, all three images are only built and published based on JDK17. Since these are all intended for testing various combinations of components to ensure compatibility and functionality, it's important for our test scenarios to cover as many supported combinations as is feasible.

## How to manually test:
1. Check out PR
2. `./gameserver/build.bash`
