### PR TITLE
fix(gameserver): ensure JDK image with Attach API is used for build

### DIFF
--- a/gameserver/Containerfile
+++ b/gameserver/Containerfile
@@ -1,4 +1,4 @@
-ARG server_img=docker.io/itzg/minecraft-server:java21
+ARG server_img=docker.io/itzg/minecraft-server:java21-jdk
 ARG agent_version
 
 FROM quay.io/cryostat/cryostat-agent-init:${agent_version} AS agent

--- a/gameserver/build.bash
+++ b/gameserver/build.bash
@@ -24,7 +24,7 @@ done
 for arch in "${ARCHS[@]}"; do
   for jdk in "${JDKS[@]}"; do
     echo "Building JDK ${jdk} for ${arch} ..."
-    podman build --build-arg server_img="docker.io/itzg/minecraft-server:java${jdk}" --build-arg agent_version="${CRYOSTAT_AGENT_VERSION,,}" --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}-jdk${jdk}" -f "${DIR}/Containerfile" "${DIR}"
+    podman build --build-arg server_img="docker.io/itzg/minecraft-server:java${jdk}-jdk" --build-arg agent_version="${CRYOSTAT_AGENT_VERSION,,}" --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}-jdk${jdk}" -f "${DIR}/Containerfile" "${DIR}"
     podman manifest add "${BUILD_IMG}:${BUILD_TAG}-jdk${jdk}" containers-storage:"${BUILD_IMG}:linux-${arch}-jdk${jdk}"
   done
 done


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #14 
There seems to be a distinction between ex. `:java17` and `java17-jdk` images, where `java17` is something like a JRE image instead of a full JDK. It doesn't contain `tools.jar` and therefore the Attach API, used by our Agent, is unavailable and attempting to attach the Agent results in a runtime error and failure of the container to start.
