### PR TITLE
ci(containers): split jobs for each sample

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,4 +1,4 @@
-name: Build Container Image
+name: Build Container Images
 
 concurrency:
   group: ci-${{ github.run_id }}
@@ -26,7 +26,7 @@ jobs:
   get-agent-version:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'cryostatio' }}
-    outputs: 
+    outputs:
       image-version: ${{ steps.get-agent-version.outputs.agent-version }}
     steps:
     - uses: actions/checkout@v4
@@ -39,15 +39,30 @@ jobs:
       run: |
         echo "agent-version=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)" >> $GITHUB_OUTPUT
 
+  get-samples:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'cryostatio' }}
+    outputs:
+      paths: ${{ steps.get-paths.outputs.paths }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+        submodules: true
+        fetch-depth: 0
+    - id: get-paths
+      run: |
+        paths=$(find . -mindepth 2 -type f -name build.bash | awk '{print "\x27" $1 "\x27"}' | head -c -1 | tr '\n' ',')
+        echo "paths=[${paths}]" >> "$GITHUB_OUTPUT"
+
   build-and-push:
-    needs: [get-agent-version]
+    needs: [get-agent-version, get-samples]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17']
+        path: ${{ fromJSON(needs.get-samples.outputs.paths) }}
     env:
       agent-version: ${{ needs.get-agent-version.outputs.image-version }}
-    name: Build Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -59,14 +74,14 @@ jobs:
         sudo apt-get install -y qemu-user-static
     - uses: actions/setup-java@v4
       with:
-        java-version: ${{ matrix.java }}
+        java-version: 17
         distribution: 'temurin'
     - name: Get date tag
       run: echo "DATE_TAG=$(date -uI)" >> "$GITHUB_ENV"
     - name: Registry login
       run: podman login quay.io --username=${{ env.CI_USER }} --password=${{ secrets.REPOSITORY_TOKEN }}
     - name: Build application
-      run: ./build.bash
+      run: bash ${{ matrix.path }}
       env:
         TAGS: ${{ env.agent-version }} ${{env.DATE_TAG}} latest
         PUSH_MANIFEST: true


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #35

## Description of the change:
Splits the CI action into a separate job for each individual sample's `build.bash`, rather than one action which runs each sequentially.

## Motivation for the change:
Parallelism for faster builds. Not yet done: building archs separately and combining into a multiarch manifest at the end.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... bash smoketest.bash...*
2. *...*
