### PR TITLE
fix(async-profiler): download arch-specific aysnc-profiler binaries

### DIFF
--- a/quarkus-agent/.gitignore
+++ b/quarkus-agent/.gitignore
@@ -1,1 +1,2 @@
 target/*
+src/main/docker/extras/async-profiler/*

--- a/quarkus-agent/build.bash
+++ b/quarkus-agent/build.bash
@@ -13,25 +13,37 @@ trap cleanup EXIT
 BUILD_IMG="${APP_REGISTRY:-quay.io}/${APP_NAMESPACE:-redhat-java-monitoring}/${APP_NAME:-quarkus-cryostat-agent}"
 BUILD_TAG="${APP_VERSION:-$(mvn -f "${DIR}/pom.xml" help:evaluate -B -q -DforceStdout -Dexpression=project.version)}"
 
-ASYNC_PROFILER="${DIR}/src/main/docker/extras/async-profiler"
-mkdir -p "${ASYNC_PROFILER}"
-if [ ! -f "${ASYNC_PROFILER}/async-profiler.jar" ] || [ ! -f "${ASYNC_PROFILER}/libasyncProfiler.so" ] || [ "${CI}" = "true" ]; then
-    ASYNC_PROFILER_TAG="$(gh -R async-profiler/async-profiler release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')"
-    ASYNC_PROFILER_VERSION="${ASYNC_PROFILER_TAG:1}"
-    ASYNC_PROFILER_ARCHIVE="async-profiler-${ASYNC_PROFILER_VERSION}-linux-x64"
-    gh -R async-profiler/async-profiler release download --dir "${ASYNC_PROFILER}" --clobber "${ASYNC_PROFILER_TAG}" -p async-profiler.jar
-    # TODO download arch-specific archive
-    gh -R async-profiler/async-profiler release download --clobber "${ASYNC_PROFILER_TAG}" -p "${ASYNC_PROFILER_ARCHIVE}.tar.gz"
-    tar xzvf "${ASYNC_PROFILER_ARCHIVE}.tar.gz"
-    mv "${ASYNC_PROFILER_ARCHIVE}/lib/libasyncProfiler.so" "${ASYNC_PROFILER}"
-    rm -rf "${ASYNC_PROFILER_ARCHIVE}" "${ASYNC_PROFILER_ARCHIVE}.tar.gz"
-fi
-
 "${DIR}/mvnw" -B -U -DskipTests -Dio.cryostat.agent.version="${CRYOSTAT_AGENT_VERSION}" clean package
 
 podman manifest create "${BUILD_IMG}:${BUILD_TAG}"
 
+function prepareAsyncProfiler() {
+    ASYNC_PROFILER="${DIR}/src/main/docker/extras/async-profiler"
+    mkdir -p "${ASYNC_PROFILER}"
+    if [ ! -f "${ASYNC_PROFILER}/async-profiler.jar" ]; then
+        rm -f "${ASYNC_PROFILER}/async-profiler.jar"
+    fi
+    if [ ! -f "${ASYNC_PROFILER}/libasyncProfiler.so" ] ; then
+        rm -f "${ASYNC_PROFILER}/libasyncProfiler.so"
+    fi
+    ASYNC_PROFILER_TAG="$(gh -R async-profiler/async-profiler release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')"
+    ASYNC_PROFILER_VERSION="${ASYNC_PROFILER_TAG:1}"
+    ASYNC_PROFILER_ARCH="x64"
+    if [ "$1" = "amd64" ]; then
+        ASYNC_PROFILER_ARCH="x64"
+    else
+        ASYNC_PROFILER_ARCH="$1"
+    fi
+    ASYNC_PROFILER_ARCHIVE="async-profiler-${ASYNC_PROFILER_VERSION}-linux-${ASYNC_PROFILER_ARCH}"
+    gh -R async-profiler/async-profiler release download --dir "${ASYNC_PROFILER}" --clobber "${ASYNC_PROFILER_TAG}" -p async-profiler.jar
+    gh -R async-profiler/async-profiler release download --clobber "${ASYNC_PROFILER_TAG}" -p "${ASYNC_PROFILER_ARCHIVE}.tar.gz"
+    tar xzvf "${ASYNC_PROFILER_ARCHIVE}.tar.gz"
+    mv "${ASYNC_PROFILER_ARCHIVE}/lib/libasyncProfiler.so" "${ASYNC_PROFILER}"
+    rm -rf "${ASYNC_PROFILER_ARCHIVE}" "${ASYNC_PROFILER_ARCHIVE}.tar.gz"
+}
+
 for arch in ${ARCHS:-amd64 arm64}; do
+    prepareAsyncProfiler "${arch}"
     echo "Building for ${arch} ..."
     podman build --pull=missing --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/src/main/docker/Dockerfile.jvm" "${DIR}"
     podman manifest add "${BUILD_IMG}:${BUILD_TAG}" containers-storage:"${BUILD_IMG}:linux-${arch}"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #113

See Cryostat's CI: https://github.com/cryostatio/cryostat/actions/runs/24267677913/job/70866096693
This is failing since merging the AgentAsyncProfilerIT. The amd64-arch run succeeds whereas the arm64 run times out and eventually fails. This looks suspicious to me since the sample app container build here was only building the amd64 async-profiler build in regardless of the actual container image arch being built, so the async-profiler `.so` would have been the wrong arch and therefore the sample application is probably crashing on startup.